### PR TITLE
Add Winest minimal frontend dashboard with validation and API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,26 @@
 # MyLearning
-These are my language that I am learning.
 
--Java 
--Pyton
-(HTML coming soon)
+Frontend สำหรับระบบ **Winest Management** (เชื่อม API ที่สร้างด้วย Spring Boot)
+
+## วิธีรันหน้าเว็บ
+
+```bash
+cd frontend
+python3 -m http.server 5500
+```
+
+จากนั้นเปิด `http://localhost:5500`
+
+## ฟีเจอร์ที่หน้าเว็บรองรับ
+
+- จัดการข้อมูลค่าย (setup/info/withdraw)
+- จัดการสมาชิก (เพิ่ม, เปลี่ยนชื่อ, เพิ่มยอด, soft delete, ดู active)
+- จัดการโปรเจกต์ (สร้าง, เปลี่ยนสถานะงาน, จ่ายเงิน, ลบ, ดูงานค้าง)
+- จัดการผู้เข้าร่วมโปรเจกต์
+- บันทึกรายได้ VT และดูประวัติ
+- ดู Statement แบบรวม/รายสมาชิก/ฝั่งค่าย
+
+## การตั้งค่า API
+
+- กรอก API Base URL ด้านบนของหน้าเว็บ เช่น `http://localhost:8080`
+- ระบบจะจำค่าไว้ใน `localStorage`

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,275 @@
+const el = (id) => document.getElementById(id);
+
+const state = {
+  apiBase: localStorage.getItem("winest_api_base") || "http://localhost:8080",
+};
+
+const toastEl = el("toast");
+el("apiBase").value = state.apiBase;
+
+function showToast(message, isError = false) {
+  toastEl.textContent = message;
+  toastEl.className = `toast show ${isError ? "error" : ""}`;
+  setTimeout(() => {
+    toastEl.className = "toast";
+  }, 2500);
+}
+
+function parseNumber(value, fieldName, min = null) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) throw new Error(`ค่า ${fieldName} ไม่ถูกต้อง`);
+  if (min !== null && n < min) throw new Error(`${fieldName} ต้องมากกว่าหรือเท่ากับ ${min}`);
+  return n;
+}
+
+function parseInteger(value, fieldName, min = 1) {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < min) {
+    throw new Error(`${fieldName} ต้องเป็นเลขจำนวนเต็มและ >= ${min}`);
+  }
+  return n;
+}
+
+async function request(path, { method = "GET", body, query } = {}) {
+  const url = new URL(`${state.apiBase}${path}`);
+  if (query) {
+    Object.entries(query).forEach(([k, v]) => url.searchParams.append(k, v));
+  }
+
+  const options = { method, headers: {} };
+  if (body !== undefined) {
+    options.headers["Content-Type"] = "application/json";
+    options.body = JSON.stringify(body);
+  }
+
+  const res = await fetch(url, options);
+  const text = await res.text();
+  const data = text ? safeJson(text) : null;
+
+  if (!res.ok) {
+    const msg = typeof data === "string" ? data : data?.message || text || `API Error ${res.status}`;
+    throw new Error(msg);
+  }
+  return data;
+}
+
+function safeJson(text) {
+  try { return JSON.parse(text); } catch { return text; }
+}
+
+function print(id, data) {
+  el(id).textContent = typeof data === "string" ? data : JSON.stringify(data, null, 2);
+}
+
+function submit(formId, fn) {
+  el(formId).addEventListener("submit", async (event) => {
+    event.preventDefault();
+    try {
+      await fn();
+    } catch (err) {
+      showToast(err.message, true);
+    }
+  });
+}
+
+el("saveApiBaseBtn").addEventListener("click", () => {
+  try {
+    const url = new URL(el("apiBase").value.trim());
+    state.apiBase = `${url.protocol}//${url.host}`;
+    localStorage.setItem("winest_api_base", state.apiBase);
+    showToast("บันทึก API Base แล้ว");
+  } catch {
+    showToast("API Base URL ไม่ถูกต้อง", true);
+  }
+});
+
+submit("companySetupForm", async () => {
+  const name = el("companyName").value.trim();
+  if (name.length < 2) throw new Error("ชื่อค่ายต้องมีอย่างน้อย 2 ตัวอักษร");
+  const res = await request("/api/company/setup", { method: "POST", query: { name } });
+  print("companyInfoOutput", res);
+  showToast("สร้างค่ายสำเร็จ");
+});
+
+el("loadCompanyInfoBtn").addEventListener("click", async () => {
+  try {
+    const res = await request("/api/company/info");
+    print("companyInfoOutput", res);
+    showToast("โหลดข้อมูลค่ายแล้ว");
+  } catch (err) {
+    showToast(err.message, true);
+  }
+});
+
+submit("withdrawForm", async () => {
+  const amount = parseNumber(el("withdrawAmount").value, "จำนวนเงินที่เบิก", 0.01);
+  const res = await request("/api/company/withdraw", { method: "POST", query: { amount } });
+  print("companyInfoOutput", res || "เบิกเงินสำเร็จ");
+  showToast("เบิกเงินสำเร็จ");
+});
+
+submit("memberForm", async () => {
+  const name = el("memberName").value.trim();
+  const age = parseInteger(el("memberAge").value, "อายุ");
+  const role = el("memberRole").value.trim();
+  if (name.length < 2 || role.length < 2) throw new Error("ชื่อและบทบาทต้องมีอย่างน้อย 2 ตัวอักษร");
+
+  const res = await request("/api/members", { method: "POST", body: { name, age, role } });
+  print("membersOutput", res);
+  showToast("เพิ่มสมาชิกแล้ว");
+});
+
+el("loadMembersBtn").addEventListener("click", async () => {
+  try {
+    const res = await request("/api/members");
+    print("membersOutput", res);
+    showToast("โหลดสมาชิกแล้ว");
+  } catch (err) {
+    showToast(err.message, true);
+  }
+});
+
+submit("updateMemberNameForm", async () => {
+  const id = parseInteger(el("updateMemberId").value, "Member ID");
+  const newName = el("updateMemberNewName").value.trim();
+  if (newName.length < 2) throw new Error("ชื่อใหม่ต้องมีอย่างน้อย 2 ตัวอักษร");
+  const res = await request(`/api/members/${id}/name`, { method: "PATCH", query: { newName } });
+  print("membersOutput", res);
+  showToast("แก้ไขชื่อสำเร็จ");
+});
+
+submit("memberBalanceForm", async () => {
+  const id = parseInteger(el("balanceMemberId").value, "Member ID");
+  const amount = parseNumber(el("balanceAmount").value, "จำนวนเงิน", 0.01);
+  const res = await request(`/api/members/${id}/add-balance`, { method: "POST", query: { amount } });
+  print("membersOutput", res || "เพิ่มยอดเงินสำเร็จ");
+  showToast("เพิ่มยอดเงินสำเร็จ");
+});
+
+submit("deleteMemberForm", async () => {
+  const id = parseInteger(el("deleteMemberId").value, "Member ID");
+  const res = await request(`/api/members/${id}`, { method: "DELETE" });
+  print("membersOutput", res || "ตั้งค่าสถานะลาออกแล้ว");
+  showToast("อัปเดตสถานะสมาชิกแล้ว");
+});
+
+submit("projectForm", async () => {
+  const name = el("projectName").value.trim();
+  const totalPrice = parseNumber(el("projectTotalPrice").value, "ราคารวม", 0.01);
+  if (name.length < 2) throw new Error("ชื่อโปรเจกต์ต้องมีอย่างน้อย 2 ตัวอักษร");
+
+  const res = await request("/api/projects", { method: "POST", query: { name, totalPrice } });
+  print("projectsOutput", res);
+  showToast("สร้างโปรเจกต์แล้ว");
+});
+
+el("loadProjectsBtn").addEventListener("click", () => loadProjects("/api/projects"));
+el("loadUnfinishedBtn").addEventListener("click", () => loadProjects("/api/projects/unfinished"));
+el("loadUnpaidBtn").addEventListener("click", () => loadProjects("/api/projects/unpaid"));
+
+async function loadProjects(path) {
+  try {
+    const res = await request(path);
+    print("projectsOutput", res);
+    showToast("โหลดข้อมูลโปรเจกต์แล้ว");
+  } catch (err) {
+    showToast(err.message, true);
+  }
+}
+
+submit("workStatusForm", async () => {
+  const id = parseInteger(el("workProjectId").value, "Project ID");
+  const isFinished = el("workFinished").value;
+  if (!["true", "false"].includes(isFinished)) throw new Error("กรุณาเลือกสถานะงาน");
+  const res = await request(`/api/projects/${id}/work-status`, { method: "PATCH", query: { isFinished } });
+  print("projectsOutput", res || "อัปเดตสถานะงานแล้ว");
+  showToast("อัปเดตสถานะงานแล้ว");
+});
+
+submit("payProjectForm", async () => {
+  const id = parseInteger(el("payProjectId").value, "Project ID");
+  const res = await request(`/api/projects/${id}/pay`, { method: "POST" });
+  print("projectsOutput", res || "ชำระเงินแล้ว");
+  showToast("จ่ายเงินโปรเจกต์แล้ว");
+});
+
+submit("deleteProjectForm", async () => {
+  const id = parseInteger(el("deleteProjectId").value, "Project ID");
+  const res = await request(`/api/projects/${id}`, { method: "DELETE" });
+  print("projectsOutput", res || "ลบโปรเจกต์แล้ว");
+  showToast("ลบโปรเจกต์แล้ว");
+});
+
+submit("addParticipantForm", async () => {
+  const projectId = parseInteger(el("participantProjectId").value, "Project ID");
+  const memberId = parseInteger(el("participantMemberId").value, "Member ID");
+  const res = await request("/api/participants/add", { method: "POST", query: { projectId, memberId } });
+  print("participantsOutput", res || "เพิ่มผู้เข้าร่วมแล้ว");
+  showToast("เพิ่มผู้เข้าร่วมแล้ว");
+});
+
+submit("removeParticipantForm", async () => {
+  const id = parseInteger(el("removeParticipantId").value, "Participant ID");
+  const res = await request(`/api/participants/${id}`, { method: "DELETE" });
+  print("participantsOutput", res || "ลบผู้เข้าร่วมแล้ว");
+  showToast("ลบผู้เข้าร่วมแล้ว");
+});
+
+submit("listParticipantsForm", async () => {
+  const projectId = parseInteger(el("listParticipantProjectId").value, "Project ID");
+  const res = await request(`/api/participants/project/${projectId}`);
+  print("participantsOutput", res);
+  showToast("โหลดผู้เข้าร่วมแล้ว");
+});
+
+submit("recordVtForm", async () => {
+  const memberId = parseInteger(el("vtMemberId").value, "Member ID");
+  const amount = parseNumber(el("vtAmount").value, "ยอดโดเนท", 0.01);
+  const res = await request("/api/vt-income/record", { method: "POST", query: { memberId, amount } });
+  print("vtOutput", res);
+  showToast("บันทึกรายได้ VT แล้ว");
+});
+
+el("loadAllVtBtn").addEventListener("click", async () => {
+  try {
+    const res = await request("/api/vt-income");
+    print("vtOutput", res);
+    showToast("โหลดรายได้ VT แล้ว");
+  } catch (err) {
+    showToast(err.message, true);
+  }
+});
+
+submit("loadMemberVtForm", async () => {
+  const memberId = parseInteger(el("loadVtMemberId").value, "Member ID");
+  const res = await request(`/api/vt-income/member/${memberId}`);
+  print("vtOutput", res);
+  showToast("โหลดรายได้ VT ตามสมาชิกแล้ว");
+});
+
+el("loadAllStatementsBtn").addEventListener("click", async () => {
+  try {
+    const res = await request("/api/statements");
+    print("statementOutput", res);
+    showToast("โหลด Statement ทั้งหมดแล้ว");
+  } catch (err) {
+    showToast(err.message, true);
+  }
+});
+
+el("loadCompanyStatementsBtn").addEventListener("click", async () => {
+  try {
+    const res = await request("/api/statements/company");
+    print("statementOutput", res);
+    showToast("โหลด Statement ฝั่งค่ายแล้ว");
+  } catch (err) {
+    showToast(err.message, true);
+  }
+});
+
+submit("loadMemberStatementsForm", async () => {
+  const memberId = parseInteger(el("statementMemberId").value, "Member ID");
+  const res = await request(`/api/statements/member/${memberId}`);
+  print("statementOutput", res);
+  showToast("โหลด Statement ตามสมาชิกแล้ว");
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Winest Management</title>
+  <link rel="stylesheet" href="./styles.css" />
+</head>
+<body>
+  <header class="hero">
+    <div>
+      <h1>Winest Management</h1>
+      <p>ระบบจัดการธุรกรรมและข้อมูลของคนในค่าย</p>
+    </div>
+    <div class="api-config">
+      <label for="apiBase">API Base URL</label>
+      <input id="apiBase" type="url" placeholder="http://localhost:8080" />
+      <button id="saveApiBaseBtn">บันทึก</button>
+    </div>
+  </header>
+
+  <main class="grid">
+    <section class="card">
+      <h2>ข้อมูลค่าย</h2>
+      <form id="companySetupForm" class="inline-form">
+        <input id="companyName" type="text" placeholder="ชื่อค่าย" required minlength="2" />
+        <button type="submit">สร้างค่าย</button>
+      </form>
+      <div class="inline-form">
+        <button id="loadCompanyInfoBtn">รีเฟรชข้อมูลค่าย</button>
+      </div>
+      <form id="withdrawForm" class="inline-form">
+        <input id="withdrawAmount" type="number" min="0.01" step="0.01" placeholder="จำนวนเงินที่เบิก" required />
+        <button type="submit">เบิกเงิน</button>
+      </form>
+      <pre id="companyInfoOutput" class="output"></pre>
+    </section>
+
+    <section class="card">
+      <h2>สมาชิก</h2>
+      <form id="memberForm" class="stack-form">
+        <input id="memberName" type="text" placeholder="ชื่อสมาชิก" required minlength="2" />
+        <input id="memberAge" type="number" min="1" max="120" placeholder="อายุ" required />
+        <input id="memberRole" type="text" placeholder="บทบาท" required minlength="2" />
+        <button type="submit">เพิ่มสมาชิก</button>
+      </form>
+      <div class="inline-form">
+        <button id="loadMembersBtn">ดึงสมาชิกที่ Active</button>
+      </div>
+      <form id="updateMemberNameForm" class="inline-form">
+        <input id="updateMemberId" type="number" min="1" placeholder="Member ID" required />
+        <input id="updateMemberNewName" type="text" minlength="2" placeholder="ชื่อใหม่" required />
+        <button type="submit">เปลี่ยนชื่อ</button>
+      </form>
+      <form id="memberBalanceForm" class="inline-form">
+        <input id="balanceMemberId" type="number" min="1" placeholder="Member ID" required />
+        <input id="balanceAmount" type="number" min="0.01" step="0.01" placeholder="จำนวนเงิน" required />
+        <button type="submit">เพิ่มยอดเงิน</button>
+      </form>
+      <form id="deleteMemberForm" class="inline-form">
+        <input id="deleteMemberId" type="number" min="1" placeholder="Member ID" required />
+        <button type="submit" class="danger">ลาออก (Soft Delete)</button>
+      </form>
+      <pre id="membersOutput" class="output"></pre>
+    </section>
+
+    <section class="card">
+      <h2>โปรเจกต์</h2>
+      <form id="projectForm" class="stack-form">
+        <input id="projectName" type="text" placeholder="ชื่อโปรเจกต์" required minlength="2" />
+        <input id="projectTotalPrice" type="number" min="0.01" step="0.01" placeholder="ราคารวม" required />
+        <button type="submit">สร้างโปรเจกต์</button>
+      </form>
+      <div class="inline-form">
+        <button id="loadProjectsBtn">ดึงโปรเจกต์ทั้งหมด</button>
+        <button id="loadUnfinishedBtn">งานยังไม่เสร็จ</button>
+        <button id="loadUnpaidBtn">งานค้างจ่าย</button>
+      </div>
+      <form id="workStatusForm" class="inline-form">
+        <input id="workProjectId" type="number" min="1" placeholder="Project ID" required />
+        <select id="workFinished" required>
+          <option value="">เลือกสถานะงาน</option>
+          <option value="true">เสร็จแล้ว</option>
+          <option value="false">ยังไม่เสร็จ</option>
+        </select>
+        <button type="submit">อัปเดตสถานะงาน</button>
+      </form>
+      <form id="payProjectForm" class="inline-form">
+        <input id="payProjectId" type="number" min="1" placeholder="Project ID" required />
+        <button type="submit">จ่ายเงินโปรเจกต์</button>
+      </form>
+      <form id="deleteProjectForm" class="inline-form">
+        <input id="deleteProjectId" type="number" min="1" placeholder="Project ID" required />
+        <button type="submit" class="danger">ลบโปรเจกต์</button>
+      </form>
+      <pre id="projectsOutput" class="output"></pre>
+    </section>
+
+    <section class="card">
+      <h2>ผู้เข้าร่วมโปรเจกต์</h2>
+      <form id="addParticipantForm" class="inline-form">
+        <input id="participantProjectId" type="number" min="1" placeholder="Project ID" required />
+        <input id="participantMemberId" type="number" min="1" placeholder="Member ID" required />
+        <button type="submit">เพิ่มผู้เข้าร่วม</button>
+      </form>
+      <form id="removeParticipantForm" class="inline-form">
+        <input id="removeParticipantId" type="number" min="1" placeholder="Participant ID" required />
+        <button type="submit" class="danger">ลบผู้เข้าร่วม</button>
+      </form>
+      <form id="listParticipantsForm" class="inline-form">
+        <input id="listParticipantProjectId" type="number" min="1" placeholder="Project ID" required />
+        <button type="submit">ดูผู้เข้าร่วมตามโปรเจกต์</button>
+      </form>
+      <pre id="participantsOutput" class="output"></pre>
+    </section>
+
+    <section class="card">
+      <h2>รายได้ VT</h2>
+      <form id="recordVtForm" class="inline-form">
+        <input id="vtMemberId" type="number" min="1" placeholder="Member ID" required />
+        <input id="vtAmount" type="number" min="0.01" step="0.01" placeholder="ยอดโดเนท" required />
+        <button type="submit">บันทึกรายได้</button>
+      </form>
+      <div class="inline-form">
+        <button id="loadAllVtBtn">รายได้ VT ทั้งหมด</button>
+      </div>
+      <form id="loadMemberVtForm" class="inline-form">
+        <input id="loadVtMemberId" type="number" min="1" placeholder="Member ID" required />
+        <button type="submit">รายได้ VT ตามสมาชิก</button>
+      </form>
+      <pre id="vtOutput" class="output"></pre>
+    </section>
+
+    <section class="card">
+      <h2>Statement / Audit</h2>
+      <div class="inline-form">
+        <button id="loadAllStatementsBtn">Statement ทั้งหมด</button>
+        <button id="loadCompanyStatementsBtn">Statement ฝั่งค่าย</button>
+      </div>
+      <form id="loadMemberStatementsForm" class="inline-form">
+        <input id="statementMemberId" type="number" min="1" placeholder="Member ID" required />
+        <button type="submit">Statement ตามสมาชิก</button>
+      </form>
+      <pre id="statementOutput" class="output"></pre>
+    </section>
+  </main>
+
+  <div id="toast" class="toast" aria-live="polite"></div>
+  <script src="./app.js"></script>
+</body>
+</html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,129 @@
+:root {
+  --bg: #f5f8ff;
+  --surface: #ffffff;
+  --primary: #2f5bff;
+  --secondary: #6d39ff;
+  --text: #111827;
+  --muted: #6b7280;
+  --border: #dbe3ff;
+  --danger: #e11d48;
+  --shadow: 0 10px 30px rgba(47, 91, 255, 0.08);
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  color: var(--text);
+  background: linear-gradient(140deg, #f8fbff 0%, #f3f0ff 100%);
+}
+
+.hero {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.25rem 1rem;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 5;
+}
+
+.hero h1 { margin: 0; color: var(--primary); }
+.hero p { margin: 0.25rem 0 0; color: var(--muted); }
+
+.api-config {
+  display: flex;
+  align-items: end;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.grid {
+  max-width: 1300px;
+  margin: 0 auto;
+  padding: 1rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: var(--shadow);
+  padding: 1rem;
+}
+
+.card h2 {
+  margin-top: 0;
+  font-size: 1.05rem;
+  color: var(--secondary);
+}
+
+.inline-form,
+.stack-form {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.stack-form { flex-direction: column; }
+
+input, select, button {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.58rem 0.7rem;
+  font-size: 0.95rem;
+}
+
+input, select {
+  background: #fbfcff;
+  flex: 1;
+  min-width: 120px;
+}
+
+button {
+  border: none;
+  color: #fff;
+  background: linear-gradient(120deg, var(--primary), var(--secondary));
+  cursor: pointer;
+  transition: transform 0.12s ease, opacity 0.2s ease;
+}
+button:hover { transform: translateY(-1px); opacity: 0.95; }
+button.danger { background: linear-gradient(120deg, #ef476f, #c11252); }
+
+.output {
+  background: #f8faff;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0.75rem;
+  min-height: 110px;
+  max-height: 260px;
+  overflow: auto;
+  font-size: 0.85rem;
+}
+
+.toast {
+  position: fixed;
+  right: 12px;
+  bottom: 12px;
+  padding: 0.7rem 0.9rem;
+  border-radius: 12px;
+  color: #fff;
+  background: #1e40af;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(12px);
+  transition: all 0.2s ease;
+}
+.toast.show { opacity: 1; transform: translateY(0); }
+.toast.error { background: #b91c1c; }
+
+@media (max-width: 600px) {
+  .hero { position: static; }
+}


### PR DESCRIPTION
### Motivation
- Provide a simple, minimal frontend so the existing Winest backend API can be used immediately for management tasks. 
- Offer a cohesive single-page UI (white / blue / purple minimal theme) to manage company, members, projects, participants, VT incomes and statements. 
- Prevent common user errors by validating inputs client-side before calling backend endpoints.

### Description
- Add a lightweight dashboard under `frontend/` with `index.html`, `styles.css`, and `app.js` implementing the UI, styles, API wiring and client-side validation. 
- Implement a reusable `request` helper for calling backend endpoints and unified response rendering in the page outputs. 
- Add input validation helpers `parseNumber` and `parseInteger`, HTML `min`/`required` constraints and form checks to prevent invalid submissions. 
- Persist API base URL in `localStorage`, add toast notifications for success/error, and update `README.md` with run instructions (`python3 -m http.server 5500`).

### Testing
- Ran JavaScript syntax check with `node --check frontend/app.js`, which succeeded. 
- Launched a static server using `python3 -m http.server 5500 --directory frontend` and confirmed the site was served with `curl -I http://127.0.0.1:5500`, which returned a successful response. 
- Attempted a Playwright screenshot of `http://localhost:5500`, but the browser tool in this environment encountered `ERR_EMPTY_RESPONSE` and the automated screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6f47ab7cc83299d241742a70392dc)